### PR TITLE
fix issue of getting status of empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - :rocket: added _match_ value wait
 - :rocket: added _I wait until {string} css property of {string} {playwrightValueWait} {string}( ){playwrightTimeout}_ step
 
+## [0.40.1]
+- :beetle: fix `Cannot read properties of undefined (reading 'status')`
+
 ## [0.40.0]
 - :rocket: added _I save bounding rect of {string} as {string}_ step
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/steps-wdio",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "steps to interact with wdio",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -56,7 +56,7 @@ AfterStep(async function (step) {
     const isOnFailScreenshot = equalOrIncludes(config.driverConfig.screenshot ?? config.screenshot, ScreenshotEvent.ON_FAIL)
     try {
         if (
-            (isOnFailScreenshot && step.result.status === Status.FAILED) ||
+            (isOnFailScreenshot && step.result?.status === Status.FAILED) ||
             isAfterStepScreenshot
         ) {
             this.attach(await browser.takeScreenshot(), 'base64:image/png');
@@ -69,7 +69,7 @@ AfterStep(async function (step) {
     const isOnFailSnapshot = equalOrIncludes(config.driverConfig.snapshot, SnapshotEvent.ON_FAIL);
     try {
         if (
-            (isOnFailSnapshot && step.result.status === Status.FAILED) ||
+            (isOnFailSnapshot && step.result?.status === Status.FAILED) ||
             isAfterStepSnapshot
         ) {
             this.attach(Buffer.from(await browser.executeAsync(getSnapshot)).toString('base64'), 'text/html');


### PR DESCRIPTION
Before submitting this PR, please ensure that you have completed the following:

- [x] Updated the CHANGELOG.md.
- [x] Checked that there aren't other open pull requests for the same issue/update.
- [x] Checked that your contribution follows the project's contribution guidelines.
- [ ] Added corresponding unit/E2E tests
- [ ] Unit and E2E pass

## Description

fix `Cannot read properties of undefined (reading 'status')` if test is failed in `Before` or `BeforeStep` hooks

### Related Issues

Haven't created.

---

Thank you for your contribution! 
